### PR TITLE
fix: correct SRI hash for Turf.js 7.3.5

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -39,7 +39,7 @@
     <script src="https://ppete2.github.io/Leaflet.PolylineMeasure/Leaflet.PolylineMeasure.js"></script>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/Turf.js/7.3.5/turf.min.js"
-      integrity="sha512-O8ZskMF0FHZoYv5HcxauhjrIkQ8NpR7wxIT7HAnPSNsNZhL1ryVhOuzRD/m5Q0nRrumiKsYuFD9s/pYnnxiEsA=="
+      integrity="sha512-VYGM6in1m8Lxo1jHldPvvR6NN/28Xy219BmWYu+UdvKAq0vOun5CDKMD0kt4j67Nc13NhEI7rFT8ZqXuDH9H5w=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"></script>
     <script src="./scripts/index.js" defer></script>


### PR DESCRIPTION
The integrity hash added in #31 does not match the file served by cdnjs,
so the browser blocks Turf.js entirely. index.js then throws at
turf.buffer(), which breaks the supermarket buffers (Task 3), the IKEA
image overlay (Task 4), and the sidebar content in Task 2 (removeIkea()
throws before sidebar.setContent runs).

Hash verified against the CDN file:
curl -s https://cdnjs.cloudflare.com/ajax/libs/Turf.js/7.3.5/turf.min.js | openssl dgst -sha512 -binary | openssl base64 -A

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jijsgkm8Lk7HX32XTrvgdu